### PR TITLE
Hide desktop entry

### DIFF
--- a/build/linux/usr/share/applications/multimc-curseforge.desktop
+++ b/build/linux/usr/share/applications/multimc-curseforge.desktop
@@ -1,6 +1,7 @@
 [Desktop Entry]
 Type=Application
 Name=MultiMC-Curseforge
-Exec=multimc-curseforge  %u
+Exec=multimc-curseforge %u
 Terminal=false
 MimeType=x-scheme-handler/curseforge;
+OnlyShowIn=


### PR DESCRIPTION
Adding `OnlyShowIn` to desktop entry causes to hide it from all DE, but still works as url handler.
Currently blank entry shown in application picker, which doesn't do anything:
![Screenshot from 2021-05-28 23-12-30](https://user-images.githubusercontent.com/1416030/120005257-43861a00-c00a-11eb-8a98-3d13e46f5eb7.png)
